### PR TITLE
Code review

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,22 +30,22 @@ Refer to `main.go` for a detailed example.
 ### Very basic usage
 
 ```go
-io := style.CreateDefaultIo()
+rw := style.CreateDefaultReadWriter()
 
-io.GetWriter().WriteLine("What's your name?")
-name, err := io.GetReader().ReadLine()
+rw.GetWriter().Writeln("What's your name?")
+name, err := rw.GetReader().ReadLine()
 if err != nil {
     panic(err)
 }
-io.GetWriter().WriteLine("Nice to meet you, " + name)
+rw.GetWriter().Writeln("Nice to meet you, " + name)
 ```
 
 ### Input handling
 
 ```go
-io := style.CreateDefaultIo()
+rw := style.CreateDefaultReadWriter()
 
-confirmed, err := io.Style().Input().Confirm("Do you want to go swimming today?", iogo.Options{Default: "y"})
+confirmed, err := rw.Style().Input().Confirm("Do you want to go swimming today?", iogo.Options{Default: "y"})
 if err != nil {
     panic(err)
 }
@@ -58,10 +58,10 @@ if confirmed {
 ### Output handling
 
 ```go
-io := style.CreateDefaultIo()
+rw := style.CreateDefaultReadWriter()
 
-io.Style().Output().Title("Welcome to iogo!")
-io.Style().Output().Success("You have installed the software correctly!")
+rw.Style().Output().Title("Welcome to iogo!")
+rw.Style().Output().Success("You have installed the software correctly!")
 ```
 
 ## License

--- a/main_test.go
+++ b/main_test.go
@@ -6,16 +6,33 @@ import (
 )
 
 func TestFunc(t *testing.T) {
-	oldStdout := os.Stdout
-	defer func() {
-		os.Stdout = oldStdout
-	}()
+	oldStdin, oldStdout := os.Stdin, os.Stdout
+	stdin, stdout, err := os.Pipe()
+	if err != nil {
+		panic(err)
+	}
+	os.Stdin, os.Stdout = stdin, nil
+	resetStdInOut := func() {
+		os.Stdin, os.Stdout = oldStdin, oldStdout
+	}
 
-	os.Stdout = nil
-	if 0 != demo([]string{"iogo", "--confirm"}) {
+	stdout.WriteString("hello\n")
+	if !demo(flags{}) {
+		resetStdInOut()
 		t.Fail()
 	}
-	if 0 != demo([]string{"iogo", "--help"}) {
+	stdout.WriteString("one\n")
+	if !demo(flags{selectFlag: true}) {
+		resetStdInOut()
 		t.Fail()
 	}
+	if demo(flags{selectFlag: true, confirmFlag: true}) {
+		resetStdInOut()
+		t.Fail()
+	}
+	if !demo(flags{selectFlag: true, confirmFlag: true, helpFlag: true}) {
+		resetStdInOut()
+		t.Fail()
+	}
+	resetStdInOut()
 }

--- a/pkg/iogo/interface.go
+++ b/pkg/iogo/interface.go
@@ -1,31 +1,31 @@
 package iogo
 
 type Reader interface {
-	ReadLine(options Options) (string, error)
+	ReadLine(opts *Options) (string, error)
 	Reset()
 }
 
 type Writer interface {
-	Write(message string)
-	WriteLine(message string)
+	Write(msg string)
+	Writeln(msg string)
 }
 
 type ReaderStyle interface {
-	Prompt(prompt string, options Options) (string, error)
-	Confirm(prompt string, options Options) (bool, error)
-	Select(prompt string, valid []string, options Options) (string, error)
+	Prompt(prompt string, opts *Options) (string, error)
+	Confirm(prompt string, opts *Options) (bool, error)
+	Select(prompt string, valid []string, opts *Options) (string, error)
 }
 
 type WriterStyle interface {
-	Title(message string)
-	Section(message string)
+	Title(msg string)
+	Section(msg string)
 
-	Block(message string, options Options)
+	Block(msg string, opts *Options)
 
-	Info(message string)
-	Success(message string)
-	Warning(message string)
-	Error(message string)
+	Info(msg string)
+	Success(msg string)
+	Warning(msg string)
+	Error(msg string)
 }
 
 type Style interface {
@@ -33,7 +33,7 @@ type Style interface {
 	Output() WriterStyle
 }
 
-type Io interface {
+type ReadWriter interface {
 	Reader() Reader
 	Writer() Writer
 	Style() Style

--- a/pkg/iogo/options.go
+++ b/pkg/iogo/options.go
@@ -12,14 +12,14 @@ const (
 )
 
 type Options struct {
-	// If no input is inserted, default to this value
+	// If no input is inserted, default to this value.
 	Default string
 
-	// Avoid appending input to the internal history list
+	// Avoid appending input to the internal history list.
 	// useful e.g. if you do not want to have passwords stored in memory for longer than necessary.
 	DoNotTrack bool
 
-	// Some output can be styled with text colour
-	FgColor term.Colour
-	BgColor term.Colour
+	// Some output can be styled with text colour.
+	FgColour term.Colour
+	BgColour term.Colour
 }

--- a/pkg/iogo/reader/history/history.go
+++ b/pkg/iogo/reader/history/history.go
@@ -5,7 +5,7 @@ type tracker struct {
 }
 
 func NewHistoryTracker(history []string) *tracker {
-	return &tracker{history: history}
+	return &tracker{history}
 }
 
 func (t tracker) Get() []string {

--- a/pkg/iogo/reader/in_memory_reader.go
+++ b/pkg/iogo/reader/in_memory_reader.go
@@ -6,7 +6,7 @@ import (
 	"github.com/zarthus/iogo/v2/pkg/iogo/reader/raw"
 )
 
-// Maintains an active list of history based in memory
+// Maintains an active list of history based in memory.
 // The moment the software closes, the history is gone.
 type inMemoryReader struct {
 	history iogo.HistoryTracker
@@ -18,32 +18,27 @@ func NewInMemoryReader() *inMemoryReader {
 	}
 }
 
-func (reader inMemoryReader) ReadLine(options iogo.Options) (string, error) {
-	input, err := raw.Read(reader.history)
-
-	if err != nil {
-		return reader.fallback(&input, options), err
+func (r inMemoryReader) ReadLine(opts *iogo.Options) (string, error) {
+	input, err := raw.Read(r.history)
+	if err == nil {
+		r.trackHistory(input, opts)
 	}
-
-	reader.trackHistory(&input, options)
-	return reader.fallback(&input, options), err
+	return r.fallback(input, opts), err
 }
 
-func (reader inMemoryReader) Reset() {
-	reader.history.Reset()
+func (r inMemoryReader) Reset() {
+	r.history.Reset()
 }
 
-func (reader inMemoryReader) fallback(input *string, options iogo.Options) string {
-	if input != nil {
-		return *input
+func (r inMemoryReader) fallback(input string, opts *iogo.Options) string {
+	if input == "" {
+		return opts.Default
 	}
-	return options.Default
+	return input
 }
 
-func (reader inMemoryReader) trackHistory(input *string, options iogo.Options) {
-	if options.DoNotTrack || input == nil || *input == "" {
-		return
+func (r inMemoryReader) trackHistory(input string, opts *iogo.Options) {
+	if !opts.DoNotTrack && input != "" {
+		r.history.Track(input)
 	}
-
-	reader.history.Track(*input)
 }

--- a/pkg/iogo/reader/raw/read.go
+++ b/pkg/iogo/reader/raw/read.go
@@ -2,22 +2,21 @@ package raw
 
 import (
 	"bufio"
+	"bytes"
 	"github.com/zarthus/iogo/v2/pkg/iogo"
 	"os"
 )
 
 func Read(tracker iogo.HistoryTracker) (string, error) {
-	reader := bufio.NewReader(os.Stdin)
+	r := bufio.NewReader(os.Stdin)
 	keyUp, keyDown := byte(iogo.KeyUp), byte(iogo.KeyDown)
 
-	var bytes []byte
+	var buf bytes.Buffer
 	for {
-		b, err := reader.ReadByte()
-
-		if err != nil {
-			//if err == io.EOF {
-			//	break
-			//}
+		if b, err := r.ReadByte(); err != nil {
+			// if err != io.EOF {
+			// 	return "", err
+			// }
 			break
 		} else if b == keyUp {
 			// TODO: modify input to history next
@@ -26,9 +25,8 @@ func Read(tracker iogo.HistoryTracker) (string, error) {
 		} else if b == '\n' {
 			break
 		} else {
-			bytes = append(bytes, b)
+			buf.WriteByte(b)
 		}
 	}
-
-	return string(bytes), nil
+	return buf.String(), nil
 }

--- a/pkg/iogo/stringtools/wrap.go
+++ b/pkg/iogo/stringtools/wrap.go
@@ -1,29 +1,16 @@
 package stringtools
 
-func Wrap(s string, maxlength uint) []string {
-	staticSlen := uint(len(s))
-	slen := staticSlen
-	if maxlength > slen {
-		return []string{s}
+func Wrap(s string, maxLength int) []string {
+	if maxLength < 0 {
+		panic("maxLength must be nonnegative")
 	}
-
 	var lines []string
-	pointer := uint(0)
-
-	for slen > maxlength {
-		if pointer > staticSlen {
-			break
+	for i := 0; i < len(s); i += maxLength {
+		j := i + maxLength
+		if j > len(s) {
+			j = len(s)
 		}
-
-		pterEnd := pointer + maxlength
-		if pterEnd > staticSlen {
-			pterEnd = staticSlen
-		}
-		lines = append(lines, s[pointer:pterEnd])
-
-		pointer += maxlength
-		slen = maxlength - slen
+		lines = append(lines, s[i:j])
 	}
-
 	return lines
 }

--- a/pkg/iogo/stringtools/wrap_test.go
+++ b/pkg/iogo/stringtools/wrap_test.go
@@ -9,7 +9,7 @@ func TestWrap(t *testing.T) {
 	cases := []struct {
 		Input     string
 		Output    string
-		Maxlength uint
+		MaxLength int
 	}{
 		{
 			"foo",
@@ -21,10 +21,15 @@ func TestWrap(t *testing.T) {
 			"foob\narba\nz",
 			4,
 		},
+		{
+			"foobarba",
+			"foob\narba",
+			4,
+		},
 	}
 
 	for i, tc := range cases {
-		actual := strings.Join(Wrap(tc.Input, tc.Maxlength), "\n")
+		actual := strings.Join(Wrap(tc.Input, tc.MaxLength), "\n")
 
 		if actual != tc.Output {
 			t.Fatalf(

--- a/pkg/iogo/style/io.go
+++ b/pkg/iogo/style/io.go
@@ -6,29 +6,29 @@ import (
 	"github.com/zarthus/iogo/v2/pkg/iogo/writer"
 )
 
-type defaultIo struct {
+type defaultReadWriter struct {
 	writer iogo.Writer
 	reader iogo.Reader
 	style  iogo.Style
 }
 
-func CreateDefaultIo() iogo.Io {
-	writ, read := writer.NewDefaultWriter(), reader.NewInMemoryReader()
-	return defaultIo{
-		writer: writ,
-		reader: read,
-		style:  createDefaultStyle(writ, read),
+func CreateDefaultReadWriter() iogo.ReadWriter {
+	w, r := writer.NewDefaultWriter(), reader.NewInMemoryReader()
+	return defaultReadWriter{
+		writer: w,
+		reader: r,
+		style:  createDefaultStyle(w, r),
 	}
 }
 
-func (io defaultIo) Reader() iogo.Reader {
-	return io.reader
+func (rw defaultReadWriter) Reader() iogo.Reader {
+	return rw.reader
 }
 
-func (io defaultIo) Writer() iogo.Writer {
-	return io.writer
+func (rw defaultReadWriter) Writer() iogo.Writer {
+	return rw.writer
 }
 
-func (io defaultIo) Style() iogo.Style {
-	return io.style
+func (rw defaultReadWriter) Style() iogo.Style {
+	return rw.style
 }

--- a/pkg/iogo/style/io_test.go
+++ b/pkg/iogo/style/io_test.go
@@ -3,5 +3,5 @@ package style
 import "testing"
 
 func TestCreateDefaultIo(t *testing.T) {
-	CreateDefaultIo()
+	CreateDefaultReadWriter()
 }

--- a/pkg/iogo/style/style.go
+++ b/pkg/iogo/style/style.go
@@ -18,10 +18,10 @@ func createDefaultStyle(writer iogo.Writer, reader iogo.Reader) iogo.Style {
 	}
 }
 
-func (style defaultStyle) Input() iogo.ReaderStyle {
-	return style.input
+func (s defaultStyle) Input() iogo.ReaderStyle {
+	return s.input
 }
 
-func (style defaultStyle) Output() iogo.WriterStyle {
-	return style.output
+func (s defaultStyle) Output() iogo.WriterStyle {
+	return s.output
 }

--- a/pkg/iogo/term/sequence.go
+++ b/pkg/iogo/term/sequence.go
@@ -19,7 +19,7 @@ const (
 	Control        EscapeSequence = 0x21
 )
 
-// note: terminals vary wildely, not all terminals may interpret the same control sequence as to mean the same thing.
+// note: terminals vary wildly, not all terminals may interpret the same control sequence as to mean the same thing.
 const (
 	Reset         ControlSequence = "\033[0m"
 	Bold          ControlSequence = "\033[1m"
@@ -45,7 +45,6 @@ func Colourize(c Colour, bright bool) string {
 
 func BackgroundColourize(c Colour, bright bool) string {
 	c += 10
-
 	if bright {
 		return fmt.Sprintf(string(bgColourLight), 60+c)
 	} else {

--- a/pkg/iogo/version.go
+++ b/pkg/iogo/version.go
@@ -1,5 +1,3 @@
 package iogo
 
-const (
-	Version = "v1.0-RC1"
-)
+const Version = "v1.0-RC1"

--- a/pkg/iogo/writer/style/style.go
+++ b/pkg/iogo/writer/style/style.go
@@ -4,14 +4,13 @@ import (
 	"github.com/zarthus/iogo/v2/pkg/iogo"
 	"github.com/zarthus/iogo/v2/pkg/iogo/stringtools"
 	"github.com/zarthus/iogo/v2/pkg/iogo/term"
-	"math"
 	"strings"
 )
 
 type writerStyle struct {
 	termcol string
 	unicode bool
-	width   uint
+	width   int
 	colours bool
 
 	reader iogo.Reader
@@ -31,79 +30,79 @@ func NewWriterStyle(writer iogo.Writer, reader iogo.Reader) iogo.WriterStyle {
 	}
 }
 
-func (style writerStyle) Title(message string) {
-	style.writer.WriteLine("")
-	style.Section(message)
-	style.writer.WriteLine("")
+func (s writerStyle) Title(msg string) {
+	s.writer.Writeln("")
+	s.Section(msg)
+	s.writer.Writeln("")
 }
 
-func (style writerStyle) Section(message string) {
-	line := strings.Repeat("=", len(message))
-
-	style.writer.WriteLine(message + "\n" + line)
+func (s writerStyle) Section(msg string) {
+	line := strings.Repeat("=", len(msg))
+	s.writer.Writeln(msg + "\n" + line)
 }
 
-func (style writerStyle) Block(message string, options iogo.Options) {
-	blocklen := math.Min(80, float64(style.width-(blockPadding*2)))
-	space := strings.Repeat(" ", int(blocklen))
+func (s writerStyle) Block(msg string, opts *iogo.Options) {
+	blockLen := min(80, s.width-(blockPadding*2))
+	space := strings.Repeat(" ", blockLen)
 	padding := strings.Repeat(" ", blockPadding)
-	msglen := len(message)
-	needsWrapping := msglen > int(style.width)
+	needsWrapping := len(msg) > s.width
 
-	var prefix string
-	var suffix string
-
-	if &options.BgColor != nil {
-		prefix = term.BackgroundColourize(options.BgColor, true)
+	var prefix, suffix string
+	if opts.BgColour != 0 {
+		prefix = term.BackgroundColourize(opts.BgColour, true)
 		suffix = string(term.Reset)
-	} else {
-		prefix = ""
-		suffix = ""
 	}
 
-	style.writer.WriteLine("")
-	style.writer.WriteLine(prefix + padding + space + padding + suffix)
-	if !needsWrapping {
-		msgpadding := strings.Repeat(" ", int(style.width)-((blockPadding)+len(message)))
-		style.writer.WriteLine(prefix + padding + message + msgpadding + suffix)
-	} else {
-		for _, msg := range stringtools.Wrap(message, style.width-blockPadding*2) {
-			msgpadding := strings.Repeat(" ", int(style.width)-((blockPadding)+len(msg)))
-			style.writer.WriteLine(prefix + padding + msg + msgpadding + suffix)
+	s.writer.Writeln("")
+	s.writer.Writeln(prefix + padding + space + padding + suffix)
+	if needsWrapping {
+		for _, msg := range stringtools.Wrap(msg, s.width-blockPadding*2) {
+			msgPadding := strings.Repeat(" ", s.width-(blockPadding+len(msg)))
+			s.writer.Writeln(prefix + padding + msg + msgPadding + suffix)
 		}
+	} else {
+		msgPadding := strings.Repeat(" ", s.width-(blockPadding+len(msg)))
+		s.writer.Writeln(prefix + padding + msg + msgPadding + suffix)
 	}
-	style.writer.WriteLine(prefix + padding + space + padding + suffix)
-	style.writer.WriteLine("")
+	s.writer.Writeln(prefix + padding + space + padding + suffix)
+	s.writer.Writeln("")
 }
 
-func (style writerStyle) Info(message string) {
-	if style.colours {
-		style.Block(message, iogo.Options{BgColor: term.Cyan})
+func (s writerStyle) Info(msg string) {
+	if s.colours {
+		s.Block(msg, &iogo.Options{BgColour: term.Cyan})
 	} else {
-		style.Block("INFO: "+message, iogo.Options{})
-	}
-}
-
-func (style writerStyle) Success(message string) {
-	if style.colours {
-		style.Block(message, iogo.Options{BgColor: term.Green})
-	} else {
-		style.Block("SUCCESS: "+message, iogo.Options{})
+		s.Block("INFO: "+msg, &iogo.Options{})
 	}
 }
 
-func (style writerStyle) Warning(message string) {
-	if style.colours {
-		style.Block(message, iogo.Options{BgColor: term.Yellow})
+func (s writerStyle) Success(msg string) {
+	if s.colours {
+		s.Block(msg, &iogo.Options{BgColour: term.Green})
 	} else {
-		style.Block("WARNING: "+message, iogo.Options{})
+		s.Block("SUCCESS: "+msg, &iogo.Options{})
 	}
 }
 
-func (style writerStyle) Error(message string) {
-	if style.colours {
-		style.Block(message, iogo.Options{BgColor: term.Red})
+func (s writerStyle) Warning(msg string) {
+	if s.colours {
+		s.Block(msg, &iogo.Options{BgColour: term.Yellow})
 	} else {
-		style.Block("ERROR: "+message, iogo.Options{})
+		s.Block("WARNING: "+msg, &iogo.Options{})
 	}
+}
+
+func (s writerStyle) Error(msg string) {
+	if s.colours {
+		s.Block(msg, &iogo.Options{BgColour: term.Red})
+	} else {
+		s.Block("ERROR: "+msg, &iogo.Options{})
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
 }

--- a/pkg/iogo/writer/writer.go
+++ b/pkg/iogo/writer/writer.go
@@ -4,17 +4,16 @@ import (
 	"fmt"
 )
 
-type defaultWriter struct {
+type DefaultWriter struct{}
+
+func NewDefaultWriter() *DefaultWriter {
+	return &DefaultWriter{}
 }
 
-func NewDefaultWriter() *defaultWriter {
-	return &defaultWriter{}
+func (w DefaultWriter) Write(msg string) {
+	fmt.Print(msg)
 }
 
-func (writer defaultWriter) Write(message string) {
-	fmt.Print(message)
-}
-
-func (writer defaultWriter) WriteLine(message string) {
-	fmt.Println(message)
+func (w DefaultWriter) Writeln(msg string) {
+	fmt.Println(msg)
 }


### PR DESCRIPTION
This looks really awesome! Works perfect in my terminal. There was definitely
nothing majorly wrong with the Go code, you've got it down pretty good. I've
taken note of some things. Some of it is just style; I _believe_ that the style
changes are in line with the spirit of Go, but that can always be up for debate :)

Language notes:
- `switch` can be nicer than `if` in Go because of no fallthrough.
- Receiver names (`func (s mystruct) ...`) are almost always one letter.
- Not much need to cache `len(str)` because it compiles to a pointer dereference
  (`string` is a `struct{b *byte, len int}` under the hood).
  - Speaking of `string` being a struct, I noticed a few bugs where a function
    would return `string` and then the code checks for `&str == nil`... this
    won't work because structs can't be nil. You can only check for `str == ""`.
- `int` should be preferred over `uint` or similar; use `if...panic` blocks for
  validation. (stdlib example: `len(str)` returns `int` even though `uint` makes
  sense too)
- Only return exported types from exported functions. I think Go should enforce
  this but oh well /o\
- Sadly Go's stdlib doesn't have integer math functions... you just have to
  implement `min` and such on your own. Go 1.8 generics make this less painful,
  but you still have to write them on your own.
- I always pass structs larger than a couple fields as pointers... it might be a
  slight premature optimization, but most libraries I know do that, so in the
  spirit of consistency...
  - I did this for `Options`... I'm realizing now after making the PR that it's
  probably better to make your `Options`-accepting functions handle `nil`
  properly. Unless you handle nil, I would actually revert these changes.
  - There are actually two other routes that I would recommend trying instead of
    passing a plain struct as options:
    1. Functional options: https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis
    2. What MongoDB does with variadic options and a fluent API:
       https://github.com/mongodb/mongo-go-driver/blob/master/mongo/options/findoptions.go
- `panic` is only for programmer errors, not user, IO, etc errors.
- Go really loves its short variable names. There's a few notable ones that are
  used ubiquitously:
  - `r` for a reader
  - `w` for a writer
  - `buf` for a buffer
  - `rw` for a reader+writer
  - `opts` for options
- I've renamed the `Io` interface to `ReadWriter` to align with the stdlib's
  `io.ReadWriter`. Also, the `Io` suffix makes it really tempting to use `io` as
  a variable name to hold it, but this conflicts with the `io` stdlib package.
- I've renamed some IO functions to align with stdlib's `io`, `fmt`, and `log`
  packages (example `WriteLine` -> `Writeln`).
- In `main_test.go`, note that the `defer` block doesn't run until the function
  returns. `t.Fail()` can panic, and I'm not sure if setting os.Stdout to nil
  will suppress its output, but resetting os.Stdout to its default _after_
  calling `t.Fail()` might cause issues, or it's not clear if it will.

Architecture comments:
- Favor few packages with many files over many packages with few files.
- Since this package is largely IO, it should implement all the usual stdlib IO
  interfaces such as `io.Reader`, `io.Writer`, etc. to maximize portability.
  - To add, maybe consider functions like `Writef` to function like `fmt.Sprintf`, plus similar functions.
- I wouldn't type `os.Stdout` or `os.Stdin` anywhere in the API except in tests.
  Have those be configurable, even if they're global-ish flags for the whole
  library. It helps with tests too.